### PR TITLE
Add queue for key presses

### DIFF
--- a/src/Direction.java
+++ b/src/Direction.java
@@ -1,0 +1,21 @@
+enum Direction {
+    LEFT(false), UP(true), RIGHT(false), DOWN(true);
+
+    private final boolean isVertical;
+
+    Direction(boolean isVertical) {
+        this.isVertical = isVertical;
+    }
+
+    boolean canChangeDirectionTo(Direction d) {
+        switch (this) {
+            case LEFT:
+            case RIGHT:
+                return d.isVertical;
+            case UP:
+            case DOWN:
+                return !d.isVertical;
+        }
+        return true;
+    }
+}

--- a/src/GameField.java
+++ b/src/GameField.java
@@ -21,10 +21,7 @@ public class GameField extends JPanel implements ActionListener{
     private int[] y = new int[ALL_DOTS];
     private int dots;
     private Timer timer;
-    private boolean left = false;
-    private boolean right = true;
-    private boolean up = false;
-    private boolean down = false;
+    private Direction direction = Direction.RIGHT;
     private boolean inGame = true;
 
     private final Snake snake=new Snake(List.of());
@@ -103,15 +100,19 @@ public class GameField extends JPanel implements ActionListener{
             y[i] = y[i-1];
             coordinates.add(new Coordinate(x[i],y[i]));
         }
-        if(left){
-            x[0] -= DOT_SIZE;
-        }
-        if(right){
-            x[0] += DOT_SIZE;
-        } if(up){
-            y[0] -= DOT_SIZE;
-        } if(down){
-            y[0] += DOT_SIZE;
+        switch (direction) {
+            case LEFT:
+                x[0] -= DOT_SIZE;
+                break;
+            case RIGHT:
+                x[0] += DOT_SIZE;
+                break;
+            case UP:
+                y[0] -= DOT_SIZE;
+                break;
+            case DOWN:
+                y[0] += DOT_SIZE;
+                break;
         }
 
         coordinates.add(new Coordinate(x[0],y[0]));
@@ -166,26 +167,27 @@ public class GameField extends JPanel implements ActionListener{
         public void keyPressed(KeyEvent e) {
             super.keyPressed(e);
             int key = e.getKeyCode();
-            if(key == KeyEvent.VK_LEFT && !right){
-                left = true;
-                up = false;
-                down = false;
-            }
-            if(key == KeyEvent.VK_RIGHT && !left){
-                right = true;
-                up = false;
-                down = false;
-            }
-
-            if(key == KeyEvent.VK_UP && !down){
-                right = false;
-                up = true;
-                left = false;
-            }
-            if(key == KeyEvent.VK_DOWN && !up){
-                right = false;
-                down = true;
-                left = false;
+            switch (key) {
+                case KeyEvent.VK_LEFT:
+                    if (direction.canChangeDirectionTo(Direction.LEFT)) {
+                        direction = Direction.LEFT;
+                    }
+                    break;
+                case KeyEvent.VK_UP:
+                    if (direction.canChangeDirectionTo(Direction.UP)) {
+                        direction = Direction.UP;
+                    }
+                    break;
+                case KeyEvent.VK_RIGHT:
+                    if (direction.canChangeDirectionTo(Direction.RIGHT)) {
+                        direction = Direction.RIGHT;
+                    }
+                    break;
+                case KeyEvent.VK_DOWN:
+                    if (direction.canChangeDirectionTo(Direction.DOWN)) {
+                        direction = Direction.DOWN;
+                    }
+                    break;
             }
         }
     }

--- a/src/GameField.java
+++ b/src/GameField.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -22,6 +23,7 @@ public class GameField extends JPanel implements ActionListener{
     private int dots;
     private Timer timer;
     private Direction direction = Direction.RIGHT;
+    private final ArrayDeque<Direction> directionsQueue = new ArrayDeque<>();
     private boolean inGame = true;
 
     private final Snake snake=new Snake(List.of());
@@ -100,6 +102,10 @@ public class GameField extends JPanel implements ActionListener{
             y[i] = y[i-1];
             coordinates.add(new Coordinate(x[i],y[i]));
         }
+        // get next direction from queue
+        if (!directionsQueue.isEmpty()) {
+            direction = directionsQueue.poll();
+        }
         switch (direction) {
             case LEFT:
                 x[0] -= DOT_SIZE;
@@ -166,26 +172,32 @@ public class GameField extends JPanel implements ActionListener{
         @Override
         public void keyPressed(KeyEvent e) {
             super.keyPressed(e);
+            // we don't want to save too many directions,
+            // otherwise game may feel uncontrollable
+            if (directionsQueue.size() > 2) {
+                return;
+            }
+            Direction lastDirection = directionsQueue.isEmpty() ? direction : directionsQueue.getLast();
             int key = e.getKeyCode();
             switch (key) {
                 case KeyEvent.VK_LEFT:
-                    if (direction.canChangeDirectionTo(Direction.LEFT)) {
-                        direction = Direction.LEFT;
+                    if (lastDirection.canChangeDirectionTo(Direction.LEFT)) {
+                        directionsQueue.add(Direction.LEFT);
                     }
                     break;
                 case KeyEvent.VK_UP:
-                    if (direction.canChangeDirectionTo(Direction.UP)) {
-                        direction = Direction.UP;
+                    if (lastDirection.canChangeDirectionTo(Direction.UP)) {
+                        directionsQueue.add(Direction.UP);
                     }
                     break;
                 case KeyEvent.VK_RIGHT:
-                    if (direction.canChangeDirectionTo(Direction.RIGHT)) {
-                        direction = Direction.RIGHT;
+                    if (lastDirection.canChangeDirectionTo(Direction.RIGHT)) {
+                        directionsQueue.add(Direction.RIGHT);
                     }
                     break;
                 case KeyEvent.VK_DOWN:
-                    if (direction.canChangeDirectionTo(Direction.DOWN)) {
-                        direction = Direction.DOWN;
+                    if (lastDirection.canChangeDirectionTo(Direction.DOWN)) {
+                        directionsQueue.add(Direction.DOWN);
                     }
                     break;
             }


### PR DESCRIPTION
This PR changes the way of processing key presses. Now instead of direct writing to variable, they are adding to the queue. When a game needs to move snake, it gets next direction from queue if it's not empty.

This gives more fluid control over the snake. For example, let's say you need to go diagonally up-right. In game's current state you need to press 'up', wait for a new frame and then press 'right'. This PR changes it, so you can press 'up' and right after that hit 'right' without waiting for a new frame.